### PR TITLE
Altered conditional from >= to > for stopping scroll for comparison o…

### DIFF
--- a/lib/ng2-SmoothScroll.directive.ts
+++ b/lib/ng2-SmoothScroll.directive.ts
@@ -194,7 +194,7 @@ class SmoothScroll {
 						currentLocation == endLocation
 					) ||
 					( // condition 3
-						internalHeight >= scrollHeight
+						internalHeight > scrollHeight
 					)
 				) { // stop
 					clearInterval(runAnimation);


### PR DESCRIPTION
When scrolling to the bottom of the container identified by containerId it will not scroll back to top because internalHeight is equal to  scrollHeight. The condition 3 should be internalHeight > scrollHeight instead of internalHeight > scrollHeight so that in the edge case of being excactly at the botton of the div (happens when scrolling all the way down with no content after the container) the scrollingupo still works.